### PR TITLE
Add func_regenerate model check before killing entity

### DIFF
--- a/scripting/instagib/roundlogic.sp
+++ b/scripting/instagib/roundlogic.sp
@@ -50,7 +50,10 @@ void RefreshRequiredEnts()
 			}
 			
 			if (StrEqual(classname, "func_regenerate")) { // Delet resupply lockers
-				AcceptEntityInput(GetEntPropEnt(i, Prop_Data, "m_hAssociatedModel"), "Kill");
+				int iModel = GetEntPropEnt(i, Prop_Data, "m_hAssociatedModel");
+				if (iModel > MaxClients && IsValidEntity(iModel))
+					AcceptEntityInput(iModel, "Kill");
+				
 				AcceptEntityInput(i, "Kill");
 			} else if (StrEqual(classname, "func_door")) { // Kill all doors
 				char name[128];


### PR DESCRIPTION
Bad maps can have `func_regenerate` without any associated model entity to destroy.
Untested