### PR TITLE
Fix error from freezetag unfreeze timer

### DIFF
--- a/scripting/instagib/rounds/freezetag.sp
+++ b/scripting/instagib/rounds/freezetag.sp
@@ -128,7 +128,6 @@ void SR_FreezeTag_Freeze(int client, bool teleport)
 		
 		SR_FreezeTag_Effect(client);
 		
-		delete UnfreezeTimer[client];
 		UnfreezeTimer[client] = CreateTimer(UnfreezeAfter, SR_FreezeTag_AutoUnfreeze, client, TIMER_FLAG_NO_MAPCHANGE);
 	}
 	
@@ -138,7 +137,7 @@ void SR_FreezeTag_Freeze(int client, bool teleport)
 
 void SR_FreezeTag_Unfreeze(int client)
 {
-	delete UnfreezeTimer[client];
+	UnfreezeTimer[client] = null;
 	
 	if (IsClientFrozen[client]) {
 		if (IsClientInGame(client) && IsClientPlaying(client) && IsPlayerAlive(client)) {
@@ -247,7 +246,7 @@ void SR_FreezeTag_OnEntCreated(int ent, const char[] classname)
 
 public Action SR_FreezeTag_AutoUnfreeze(Handle timer, int client)
 {
-	if (IsClientInGame(client)) {
+	if (UnfreezeTimer[client] == timer && IsClientInGame(client)) {
 		UnfreezeTimer[client] = null;
 		RequestFrame(SR_FreezeTag_Frame_Unfreeze, client);
 		
@@ -274,8 +273,7 @@ void SR_FreezeTag_OnEnd(TFTeam winner_team, int score, int time_left)
 		}
 		
 		IsClientFrozen[i] = false;
-		
-		delete UnfreezeTimer[i];
+		UnfreezeTimer[i] = null;
 	}
 }
 

--- a/scripting/instagib/rounds/freezetag.sp
+++ b/scripting/instagib/rounds/freezetag.sp
@@ -128,6 +128,7 @@ void SR_FreezeTag_Freeze(int client, bool teleport)
 		
 		SR_FreezeTag_Effect(client);
 		
+		delete UnfreezeTimer[client];
 		UnfreezeTimer[client] = CreateTimer(UnfreezeAfter, SR_FreezeTag_AutoUnfreeze, client, TIMER_FLAG_NO_MAPCHANGE);
 	}
 	
@@ -137,7 +138,7 @@ void SR_FreezeTag_Freeze(int client, bool teleport)
 
 void SR_FreezeTag_Unfreeze(int client)
 {
-	UnfreezeTimer[client] = null;
+	delete UnfreezeTimer[client];
 	
 	if (IsClientFrozen[client]) {
 		if (IsClientInGame(client) && IsClientPlaying(client) && IsPlayerAlive(client)) {
@@ -246,12 +247,13 @@ void SR_FreezeTag_OnEntCreated(int ent, const char[] classname)
 
 public Action SR_FreezeTag_AutoUnfreeze(Handle timer, int client)
 {
-	if (UnfreezeTimer[client] == timer && IsClientInGame(client)) {
-		UnfreezeTimer[client] = null;
+	if (IsClientInGame(client)) {
 		RequestFrame(SR_FreezeTag_Frame_Unfreeze, client);
 		
 		Forward_Unfrozen(client, 0);
 	}
+	
+	UnfreezeTimer[client] = null;
 }
 
 void SR_FreezeTag_OnDisconnect(int client)
@@ -273,7 +275,8 @@ void SR_FreezeTag_OnEnd(TFTeam winner_team, int score, int time_left)
 		}
 		
 		IsClientFrozen[i] = false;
-		UnfreezeTimer[i] = null;
+		
+		delete UnfreezeTimer[i];
 	}
 }
 


### PR DESCRIPTION
Using `delete` on timer handle is bad, as those are temporary handles giving error log.

Instead of using `delete`, set global variable `null` and add a check in timer callback instead. Timer callback will be called but same handle check in callback prevents it doing anything.

`KillTimer` could be used instead, but im unsure if that should be used or preferred over this fix instead.