### PR TITLE
Fix compile errors and warnings for SM 1.11

### DIFF
--- a/scripting/include/instagib.inc
+++ b/scripting/include/instagib.inc
@@ -44,18 +44,18 @@ enum struct InstagibRound
 	int MainWeaponClip;
 	bool IsAmmoInfinite;
 	
-	Round_OnStart OnStart;
-	Round_OnEnd OnEnd;
-	Round_OnSpawn OnPlayerSpawn;
-	Round_OnPostInvApp OnPostInvApp;
-	Round_OnDeath OnPlayerDeath;
-	Round_OnTraceAttack OnTraceAttack;
-	Round_OnEntityCreated OnEntCreated;
-	Round_OnDisconnect OnPlayerDisconnect;
-	Round_OnTeamChange OnTeamChange;
-	Round_OnClassChange OnClassChange;
-	Round_OnTakeDamage OnDamageTaken;
-	Round_CustomDescription OnDescriptionPrint;
+	Function OnStart;
+	Function OnEnd;
+	Function OnPlayerSpawn;
+	Function OnPostInvApp;
+	Function OnPlayerDeath;
+	Function OnTraceAttack;
+	Function OnEntCreated;
+	Function OnPlayerDisconnect;
+	Function OnTeamChange;
+	Function OnClassChange;
+	Function OnDamageTaken;
+	Function OnDescriptionPrint;
 }
 
 typedef Round_OnStart =           function void ();

--- a/scripting/instagib.sp
+++ b/scripting/instagib.sp
@@ -269,7 +269,7 @@ void InstagibForceRoundEnd()
 	}
 }
 
-char InstagibHudPlayerInfo(int client)
+char[] InstagibHudPlayerInfo(int client)
 {
 	char str[64];
 	
@@ -428,7 +428,7 @@ void CheckForInstagibEnts()
 	}
 }
 
-char GetMapName()
+char[] GetMapName()
 {
 	char mapname[256];
 	char displayname[256];
@@ -481,6 +481,7 @@ public Action Timer_Respawn(Handle timer, int client)
 	if (IsClientInGame(client) && !IsPlayerAlive(client)) {
 		TF2_RespawnPlayer(client);
 	}
+	return Plugin_Continue;
 }
 
 public Action Timer_WelcomeMessage(Handle timer, int client)
@@ -488,6 +489,7 @@ public Action Timer_WelcomeMessage(Handle timer, int client)
 	if (IsClientInGame(client)) {
 		InstagibPrintToChat(true, client, "Welcome to Instagib v" ... INSTAGIB_VERSION ... "! \nType {/instagib} to open the menu.");
 	}
+	return Plugin_Continue;
 }
 
 public Action Timer_RemoveUber(Handle timer)
@@ -497,6 +499,7 @@ public Action Timer_RemoveUber(Handle timer)
 			TF2_RemoveCondition(i, TFCond_Ubercharged);
 		}
 	}
+	return Plugin_Continue;
 }
 
 public Action Hook_TraceAttack(int victim, int &attacker, int &inflictor, float& damage, int& damagetype, int& ammotype, int hitbox, int hitgroup)
@@ -736,6 +739,7 @@ public Action TF2_CalcIsAttackCritical(int client, int weapon, char[] weaponname
 			delete trace;
 		}
 	}
+	return Plugin_Continue;
 }
 
 public void OnClientDisconnect(int client)

--- a/scripting/instagib/commands.sp
+++ b/scripting/instagib/commands.sp
@@ -94,6 +94,7 @@ public Action Command_ReloadConfig(int client, int args)
 public Action Command_EditMode(int client, int args)
 {
 	ToggleEditMode(client);
+	return Plugin_Handled;
 }
 
 public Action Command_SetRoundTime(int client, int args)
@@ -107,6 +108,7 @@ public Action Command_SetRoundTime(int client, int args)
 			g_RoundTimeLeft = time;
 		}
 	}
+	return Plugin_Handled;
 }
 
 // Return the cheat flag to the mp_forcewin command after it's been called by the server :)
@@ -116,4 +118,5 @@ public Action ForceWinListener(int client, const char[] command, int argc)
 		int flags = GetCommandFlags("mp_forcewin");
 		SetCommandFlags("mp_forcewin", flags | FCVAR_CHEAT);
 	}
+	return Plugin_Continue;
 }

--- a/scripting/instagib/events.sp
+++ b/scripting/instagib/events.sp
@@ -213,6 +213,7 @@ public Action Event_SetupFinish(Event event, const char[] name, bool dont_broadc
 			}
 		}
 	}
+	return Plugin_Continue;
 }
 
 public Action Event_OnTeamChange(Event event, const char[] name, bool dont_broadcast)
@@ -226,6 +227,7 @@ public Action Event_OnTeamChange(Event event, const char[] name, bool dont_broad
 		Call_PushCell(team);
 		Call_Finish();
 	}
+	return Plugin_Continue;
 }
 
 public Action Event_OnClassChange(Event event, const char[] name, bool dont_broadcast)
@@ -239,4 +241,5 @@ public Action Event_OnClassChange(Event event, const char[] name, bool dont_broa
 		Call_PushCell(class);
 		Call_Finish();
 	}
+	return Plugin_Continue;
 }

--- a/scripting/instagib/hud.sp
+++ b/scripting/instagib/hud.sp
@@ -32,4 +32,5 @@ public Action Timer_DisplayHudText(Handle timer)
 			}
 		}
 	}
+	return Plugin_Continue;
 }

--- a/scripting/instagib/menus/menu_forceround.sp
+++ b/scripting/instagib/menus/menu_forceround.sp
@@ -26,4 +26,5 @@ public int ForceRound_Handler(Menu menu, MenuAction action, int client, int opti
 	} else if (action == MenuAction_End) {
 		delete menu;
 	}
+	return 0;
 }

--- a/scripting/instagib/menus/menu_main.sp
+++ b/scripting/instagib/menus/menu_main.sp
@@ -59,6 +59,7 @@ public int MenuMain_Handler(Menu menu, MenuAction action, int client, int option
 	} else if (action == MenuAction_End) {
 		delete menu;
 	}
+	return 0;
 }
 
 public int Credits_Handler(Menu menu, MenuAction action, int client, int option)
@@ -66,4 +67,5 @@ public int Credits_Handler(Menu menu, MenuAction action, int client, int option)
 	if (action == MenuAction_Select) {
 		Menu_Main(client);
 	}
+	return 0;
 }

--- a/scripting/instagib/menus/menu_mapconfig.sp
+++ b/scripting/instagib/menus/menu_mapconfig.sp
@@ -136,4 +136,5 @@ public int Panel_EditMode_Handler(Menu menu, MenuAction action, int client, int 
 			Panel_EditMode(client);
 		}
 	}
+	return 0;
 }

--- a/scripting/instagib/menus/menu_settings.sp
+++ b/scripting/instagib/menus/menu_settings.sp
@@ -84,4 +84,5 @@ public int Settings_Handler(Menu menu, MenuAction action, int client, int option
 	} else if (action == MenuAction_End) {
 		delete menu;
 	}
+	return 0;
 }

--- a/scripting/instagib/music.sp
+++ b/scripting/instagib/music.sp
@@ -132,4 +132,5 @@ public Action Timer_CycleMusic(Handle timer)
 		StopMusic();
 		PlayRandomMusic();
 	}
+	return Plugin_Continue;
 }

--- a/scripting/instagib/natives.sp
+++ b/scripting/instagib/natives.sp
@@ -118,6 +118,7 @@ public int Native_ForceSpecial(Handle plugin, int numParams)
 public int Native_CurrentRound(Handle plugin, int numParams)
 {
 	SetNativeArray(1, g_CurrentRound, sizeof(InstagibRound));
+	return 0;
 }
 
 public int Native_GetTeamScore(Handle plugin, int numParams)
@@ -169,6 +170,7 @@ public int Native_SetMaxScore(Handle plugin, int numParams)
 	int value = GetNativeCell(1);
 	
 	SetMaxScore(value);
+	return 0;
 }
 
 public int Native_GetRoundTime(Handle plugin, int numParams)
@@ -183,6 +185,7 @@ public int Native_SetRoundTime(Handle plugin, int numParams)
 	if (amount > 0) {
 		g_RoundTimeLeft = amount;
 	}
+	return 0;
 }
 
 public int Native_GetMultikill(Handle plugin, int numParams)
@@ -203,6 +206,7 @@ public int Native_SetLives(Handle plugin, int numParams)
 	int client = GetNativeCell(1);
 	int amount = GetNativeCell(2);
 	SR_Lives_SetLives(client, amount);
+	return 0;
 }
 
 public int Native_Freeze(Handle plugin, int numParams)
@@ -210,6 +214,7 @@ public int Native_Freeze(Handle plugin, int numParams)
 	int client = GetNativeCell(1);
 	SR_FreezeTag_Freeze(client, false);
 	Forward_Frozen(client, 0);
+	return 0;
 }
 
 public int Native_Unfreeze(Handle plugin, int numParams)
@@ -217,6 +222,7 @@ public int Native_Unfreeze(Handle plugin, int numParams)
 	int client = GetNativeCell(1);
 	SR_FreezeTag_Unfreeze(client);
 	Forward_Unfrozen(client, 0);
+	return 0;
 }
 
 public int Native_InitRound(Handle plugin, int numParams)
@@ -231,6 +237,7 @@ public int Native_InitRound(Handle plugin, int numParams)
 	NewInstagibRound(buffer, name, desc, plugin);
 	
 	SetNativeArray(1, buffer, sizeof(buffer));
+	return 0;
 }
 
 public int Native_SubmitRound(Handle plugin, int numParams)
@@ -239,6 +246,7 @@ public int Native_SubmitRound(Handle plugin, int numParams)
 	GetNativeArray(1, round, sizeof(round));
 	
 	SubmitInstagibRound(round);
+	return 0;
 }
 
 public int Native_ConfigNum(Handle plugin, int numParams)
@@ -278,4 +286,5 @@ public int Native_ConfigString(Handle plugin, int numParams)
 	SpecialRoundConfig_String(round, key, buffer, sizeof(buffer), defvalue);
 	
 	SetNativeString(3, buffer, GetNativeCell(4));
+	return 0;
 }

--- a/scripting/instagib/rounds/freezetag.sp
+++ b/scripting/instagib/rounds/freezetag.sp
@@ -254,6 +254,7 @@ public Action SR_FreezeTag_AutoUnfreeze(Handle timer, int client)
 	}
 	
 	UnfreezeTimer[client] = null;
+	return Plugin_Continue;
 }
 
 void SR_FreezeTag_OnDisconnect(int client)

--- a/scripting/instagib/web.sp
+++ b/scripting/instagib/web.sp
@@ -1,5 +1,5 @@
 // -------------------------------------------------------------------
-static char GetMessage(HTTPRequestHandle HTTPRequest)
+static char[] GetMessage(HTTPRequestHandle HTTPRequest)
 {
 	int size = Steam_GetHTTPResponseBodySize(HTTPRequest);
 	char[] response = new char[size];
@@ -139,6 +139,7 @@ public int Web_GetLatestInstagibVersion_OnComplete(HTTPRequestHandle HTTPRequest
 	}
 	
 	Steam_ReleaseHTTPRequest(HTTPRequest);
+	return 0;
 }
 
 public int Web_GetMapConfigs_OnComplete(HTTPRequestHandle HTTPRequest, bool requestSuccessful, HTTPStatusCode statusCode, int contextData)
@@ -168,6 +169,7 @@ public int Web_GetMapConfigs_OnComplete(HTTPRequestHandle HTTPRequest, bool requ
 	}
 	
 	Steam_ReleaseHTTPRequest(HTTPRequest);
+	return 0;
 }
 
 public int Web_DownloadMapConfig_OnComplete(HTTPRequestHandle HTTPRequest, bool requestSuccessful, HTTPStatusCode statusCode, ArrayStack data)
@@ -197,4 +199,5 @@ public int Web_DownloadMapConfig_OnComplete(HTTPRequestHandle HTTPRequest, bool 
 	}
 	
 	Steam_ReleaseHTTPRequest(HTTPRequest);
+	return 0;
 }


### PR DESCRIPTION
1.11 can't handle named typedefs in structs, and requires explicit return values for every function. 