### PR TITLE
Use Server-Sided Tracers

### DIFF
--- a/scripting/instagib/particles.sp
+++ b/scripting/instagib/particles.sp
@@ -37,6 +37,33 @@ void TE_SpawnParticle(char[] particle_name, float vecOrigin[3], float vecStart[3
 	TE_WriteFloat("m_vecStart[2]", vecStart[2]);
 	
 	TE_WriteVector("m_vecAngles", vecAngles); // doesn't do shit?
+
+	TE_WriteNum("m_bControlPoint1", 0);
+	
+	TE_WriteFloat("m_ControlPoint1.m_vecOffset[0]", vecStart[0]);
+	TE_WriteFloat("m_ControlPoint1.m_vecOffset[1]", vecStart[1]);
+	TE_WriteFloat("m_ControlPoint1.m_vecOffset[2]", vecStart[2]);
+	
+	TE_SendToAll();
+}
+
+void TE_SpawnTracerParticle(char[] particle_name, float vecOrigin[3], float m_vecOffset[3]) 
+{
+	int strindx = FindParticle(particle_name);
+	
+	TE_Start("TFParticleEffect");
+	TE_WriteNum("m_iParticleSystemIndex", strindx);
+	
+	TE_WriteFloat("m_vecOrigin[0]", vecOrigin[0]);
+	TE_WriteFloat("m_vecOrigin[1]", vecOrigin[1]);
+	TE_WriteFloat("m_vecOrigin[2]", vecOrigin[2]);
+	
+	TE_WriteNum("m_iAttachType", 2);
+	TE_WriteNum("m_bControlPoint1", 5);
+	
+	TE_WriteFloat("m_ControlPoint1.m_vecOffset[0]", m_vecOffset[0]);
+	TE_WriteFloat("m_ControlPoint1.m_vecOffset[1]", m_vecOffset[1]);
+	TE_WriteFloat("m_ControlPoint1.m_vecOffset[2]", m_vecOffset[2]);
 	
 	TE_SendToAll();
 }

--- a/scripting/instagib/rounds/headshots.sp
+++ b/scripting/instagib/rounds/headshots.sp
@@ -27,7 +27,6 @@ static Handle SR_Headshots_Railgun()
 	TF2Items_SetAttribute(hndl, 2, 2, 10.0);    // +900% damage bonus
 	TF2Items_SetAttribute(hndl, 3, 106, 0.0);   // +100% more accurate
 	TF2Items_SetAttribute(hndl, 4, 51, 1.0);    // Crits on headshot
-	TF2Items_SetAttribute(hndl, 5, 305, -1.0);  // Fires tracer rounds
 	TF2Items_SetAttribute(hndl, 6, 851, 2.0);   // i am speed
 	if (g_Config.EnabledKillstreaks) {
 		TF2Items_SetAttribute(hndl, 7, 2025, 1.0);  // killstreak

--- a/scripting/instagib/rounds/oprailguns.sp
+++ b/scripting/instagib/rounds/oprailguns.sp
@@ -26,7 +26,6 @@ static Handle SR_OPRailguns_CreateOPRailgun()
 	TF2Items_SetAttribute(hndl, 2, 2, 10.0);    // +900% damage bonus
 	TF2Items_SetAttribute(hndl, 3, 106, 0.0);   // +100% more accurate
 	TF2Items_SetAttribute(hndl, 4, 51, 1.0);    // Crits on headshot
-	TF2Items_SetAttribute(hndl, 5, 305, -1.0);  // Fires tracer rounds
 	TF2Items_SetAttribute(hndl, 6, 851, 2.0);   // i am speed
 	if (g_Config.EnabledKillstreaks) {
 		TF2Items_SetAttribute(hndl, 7, 2025, 1.0);  // killstreak


### PR DESCRIPTION
Replaces the attribute version of the sniper tracer with a server-sided particle. This helps with client-sided being inconsistent, especially at higher latencies.