### PR TITLE
Case sensitive steamworks include

### DIFF
--- a/scripting/instagib.sp
+++ b/scripting/instagib.sp
@@ -24,7 +24,7 @@
 #endif
 
 #undef REQUIRE_EXTENSIONS
-#include <steamworks>
+#include <SteamWorks>
 
 #pragma semicolon 1
 #pragma newdecls required


### PR DESCRIPTION
In linux or atleast in some cases, file reading is case sensitive while SteamWorks.inc tends to have caps lock