### PR TITLE
Fix clients unable to be damaged after as ghost

### DIFF
--- a/scripting/instagib.sp
+++ b/scripting/instagib.sp
@@ -42,23 +42,6 @@ enum
 	SOLID_LAST,
 }
 
-enum
-{
-	FSOLID_CUSTOMRAYTEST		= 0x0001,	// Ignore solid type + always call into the entity for ray tests
-	FSOLID_CUSTOMBOXTEST		= 0x0002,	// Ignore solid type + always call into the entity for swept box tests
-	FSOLID_NOT_SOLID			= 0x0004,	// Are we currently not solid?
-	FSOLID_TRIGGER				= 0x0008,	// This is something may be collideable but fires touch functions
-											// even when it's not collideable (when the FSOLID_NOT_SOLID flag is set)
-	FSOLID_NOT_STANDABLE		= 0x0010,	// You can't stand on this
-	FSOLID_VOLUME_CONTENTS		= 0x0020,	// Contains volumetric contents (like water)
-	FSOLID_FORCE_WORLD_ALIGNED	= 0x0040,	// Forces the collision rep to be world-aligned even if it's SOLID_BSP or SOLID_VPHYSICS
-	FSOLID_USE_TRIGGER_BOUNDS	= 0x0080,	// Uses a special trigger bounds separate from the normal OBB
-	FSOLID_ROOT_PARENT_ALIGNED	= 0x0100,	// Collisions are defined in root parent's local coordinate space
-	FSOLID_TRIGGER_TOUCH_DEBRIS	= 0x0200,	// This trigger will touch debris objects
-
-	FSOLID_MAX_BITS	= 10
-}
-
 enum struct Config
 {
 	char ChatColor[16];

--- a/scripting/instagib/rounds/limitedlives.sp
+++ b/scripting/instagib/rounds/limitedlives.sp
@@ -178,7 +178,6 @@ void SR_Lives_OnSpawn(int client, TFTeam team)
 		
 		// Apparently sometimes ghosts keep their player collisions, so let's take care of that.
 		SetEntProp(client, Prop_Send, "m_nSolidType", SOLID_NONE);
-		SetEntProp(client, Prop_Send, "m_usSolidFlags", FSOLID_NOT_SOLID);
 	}
 }
 
@@ -220,7 +219,6 @@ void SR_Lives_OnEnd(TFTeam winner_team, int score, int time_left)
 		if (IsClientInGame(i)) {
 			// Reset the collisions.
 			SetEntProp(i, Prop_Send, "m_nSolidType", SOLID_BBOX);
-			SetEntProp(i, Prop_Send, "m_usSolidFlags", FSOLID_NOT_STANDABLE);
 		}
 	}
 	


### PR DESCRIPTION
Changing `m_usSolidFlags` made bullet traces unable to hit player, but resetting it does not work properly, carrying over next round.

Changing that property for Limited Lives is infact unneeded, as Freeze Tag special round proves it as not needed, so best to just remove it.

Thanks to @Batfoxkid for suggestions and investigations on this.